### PR TITLE
[Feat #9] refresh token management with redis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/wap/cano_be/config/RedisConfig.java
+++ b/src/main/java/com/wap/cano_be/config/RedisConfig.java
@@ -1,6 +1,6 @@
 package com.wap.cano_be.config;
 
-import lombok.Value;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;

--- a/src/main/java/com/wap/cano_be/config/RedisConfig.java
+++ b/src/main/java/com/wap/cano_be/config/RedisConfig.java
@@ -1,2 +1,22 @@
-package com.wap.cano_be.config;public class RedisConfig {
+package com.wap.cano_be.config;
+
+import lombok.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
 }

--- a/src/main/java/com/wap/cano_be/config/RedisConfig.java
+++ b/src/main/java/com/wap/cano_be/config/RedisConfig.java
@@ -1,0 +1,2 @@
+package com.wap.cano_be.config;public class RedisConfig {
+}

--- a/src/main/java/com/wap/cano_be/controller/AuthController.java
+++ b/src/main/java/com/wap/cano_be/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.wap.cano_be.controller;
 
 import com.wap.cano_be.dto.auth.LoginRequestDto;
+import com.wap.cano_be.service.AuthService;
 import com.wap.cano_be.service.impl.KakaoOAuth2LoginService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -8,16 +9,17 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/auth")
 public class AuthController {
-    private final KakaoOAuth2LoginService oAuth2LoginService;
+    private final AuthService authService;
 
-    @GetMapping("/oauth2/callback-test")
+    @GetMapping("/callback-test/kakao")
     public String callbackTest(@RequestParam("code") String code) {
         return "Authorization Code: " + code;
     }
 
-    @PostMapping("/oauth2/login/kakao")
+    @PostMapping("/login/kakao")
     public ResponseEntity<?> getUserInfo(@RequestBody LoginRequestDto requestDto) {
-        return oAuth2LoginService.kakaoLogin(requestDto);
+        return authService.kakaoLogin(requestDto);
     }
 }

--- a/src/main/java/com/wap/cano_be/controller/AuthController.java
+++ b/src/main/java/com/wap/cano_be/controller/AuthController.java
@@ -1,7 +1,6 @@
 package com.wap.cano_be.controller;
 
-import com.google.gson.JsonObject;
-import com.wap.cano_be.dto.oauth2.TestLoginDto;
+import com.wap.cano_be.dto.auth.LoginRequestDto;
 import com.wap.cano_be.service.impl.KakaoOAuth2LoginService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -9,7 +8,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-public class OAuth2TestController {
+public class AuthController {
     private final KakaoOAuth2LoginService oAuth2LoginService;
 
     @GetMapping("/oauth2/callback-test")
@@ -18,7 +17,7 @@ public class OAuth2TestController {
     }
 
     @PostMapping("/oauth2/login/kakao")
-    public ResponseEntity<?> getUserInfo(@RequestBody TestLoginDto requestDto) {
+    public ResponseEntity<?> getUserInfo(@RequestBody LoginRequestDto requestDto) {
         return oAuth2LoginService.kakaoLogin(requestDto);
     }
 }

--- a/src/main/java/com/wap/cano_be/controller/MemberController.java
+++ b/src/main/java/com/wap/cano_be/controller/MemberController.java
@@ -5,7 +5,7 @@ import com.wap.cano_be.domain.Member;
 import com.wap.cano_be.domain.PrincipalDetail;
 import com.wap.cano_be.dto.member.MemberRequestDto;
 import com.wap.cano_be.dto.member.MemberResponseDto;
-import com.wap.cano_be.dto.oauth2.OAuth2LoginDto;
+import com.wap.cano_be.dto.auth.OAuth2LoginDto;
 import com.wap.cano_be.service.impl.MemberService;
 import com.wap.cano_be.service.OAuth2LoginService;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/wap/cano_be/domain/Member.java
+++ b/src/main/java/com/wap/cano_be/domain/Member.java
@@ -25,9 +25,4 @@ public class Member {
     private MemberRole role;
     @Enumerated(EnumType.STRING)
     private Gender gender;
-
-    @Setter
-    @OneToOne
-    @JoinColumn(name="refreshtoken_id", unique = true)
-    private RefreshToken refreshToken;
 }

--- a/src/main/java/com/wap/cano_be/domain/RefreshToken.java
+++ b/src/main/java/com/wap/cano_be/domain/RefreshToken.java
@@ -1,13 +1,18 @@
 package com.wap.cano_be.domain;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.redis.core.RedisHash;
 
-@Entity
+@Getter
+@AllArgsConstructor
+@RedisHash(value = "refresh_token", timeToLive = 604800)
 public class RefreshToken {
-    @Id @GeneratedValue(strategy = GenerationType.AUTO)
-    private long id;
-    @Column(length = 1500)
+    @Id
     private String refreshToken;
+
+    private Long userId;
 
     public RefreshToken() {
     }

--- a/src/main/java/com/wap/cano_be/domain/RefreshToken.java
+++ b/src/main/java/com/wap/cano_be/domain/RefreshToken.java
@@ -1,8 +1,8 @@
 package com.wap.cano_be.domain;
 
-import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 
 @Getter

--- a/src/main/java/com/wap/cano_be/dto/auth/LoginRequestDto.java
+++ b/src/main/java/com/wap/cano_be/dto/auth/LoginRequestDto.java
@@ -1,0 +1,8 @@
+package com.wap.cano_be.dto.auth;
+
+import lombok.Data;
+
+@Data
+public class LoginRequestDto {
+    private String token;
+}

--- a/src/main/java/com/wap/cano_be/dto/auth/LoginResponseDto.java
+++ b/src/main/java/com/wap/cano_be/dto/auth/LoginResponseDto.java
@@ -1,0 +1,11 @@
+package com.wap.cano_be.dto.auth;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class LoginResponseDto {
+    private final String accessToken;
+    private final String refreshToken;
+}

--- a/src/main/java/com/wap/cano_be/dto/auth/OAuth2LoginDto.java
+++ b/src/main/java/com/wap/cano_be/dto/auth/OAuth2LoginDto.java
@@ -1,4 +1,4 @@
-package com.wap.cano_be.dto.oauth2;
+package com.wap.cano_be.dto.auth;
 
 public record OAuth2LoginDto(
         String token,

--- a/src/main/java/com/wap/cano_be/dto/auth/OAuth2UserInfo.java
+++ b/src/main/java/com/wap/cano_be/dto/auth/OAuth2UserInfo.java
@@ -1,4 +1,4 @@
-package com.wap.cano_be.dto.oauth2;
+package com.wap.cano_be.dto.auth;
 
 import jakarta.security.auth.message.AuthException;
 import lombok.Builder;

--- a/src/main/java/com/wap/cano_be/dto/auth/OAuth2UserResponseDto.java
+++ b/src/main/java/com/wap/cano_be/dto/auth/OAuth2UserResponseDto.java
@@ -1,4 +1,4 @@
-package com.wap.cano_be.dto.oauth2;
+package com.wap.cano_be.dto.auth;
 
 import com.wap.cano_be.common.ResponseCode;
 import com.wap.cano_be.common.ResponseDto;

--- a/src/main/java/com/wap/cano_be/dto/oauth2/TestLoginDto.java
+++ b/src/main/java/com/wap/cano_be/dto/oauth2/TestLoginDto.java
@@ -1,8 +1,0 @@
-package com.wap.cano_be.dto.oauth2;
-
-import lombok.Data;
-
-@Data
-public class TestLoginDto {
-    private String token;
-}

--- a/src/main/java/com/wap/cano_be/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/wap/cano_be/repository/RefreshTokenRepository.java
@@ -2,6 +2,7 @@ package com.wap.cano_be.repository;
 
 import com.wap.cano_be.domain.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.CrudRepository;
 
-public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
 }

--- a/src/main/java/com/wap/cano_be/security/JwtConstants.java
+++ b/src/main/java/com/wap/cano_be/security/JwtConstants.java
@@ -1,8 +1,8 @@
 package com.wap.cano_be.security;
 
 public class JwtConstants {
-    public static final int ACCESS_EXP_TIME = 10;   // 10분
-    public static final int REFRESH_EXP_TIME = 60 * 24;   // 24시간
+    public static final int ACCESS_EXP_TIME = 60;   // 1시간
+    public static final int REFRESH_EXP_TIME = 60 * 24 * 7;   // 1주일
 
     public static final String JWT_HEADER = "Authorization";
     public static final String JWT_TYPE = "Bearer ";

--- a/src/main/java/com/wap/cano_be/service/AuthService.java
+++ b/src/main/java/com/wap/cano_be/service/AuthService.java
@@ -1,0 +1,9 @@
+package com.wap.cano_be.service;
+
+import com.wap.cano_be.dto.auth.LoginRequestDto;
+import com.wap.cano_be.dto.auth.LoginResponseDto;
+import org.springframework.http.ResponseEntity;
+
+public interface AuthService {
+    ResponseEntity<LoginResponseDto> kakaoLogin (LoginRequestDto requestDto);
+}

--- a/src/main/java/com/wap/cano_be/service/OAuth2LoginService.java
+++ b/src/main/java/com/wap/cano_be/service/OAuth2LoginService.java
@@ -1,11 +1,11 @@
 package com.wap.cano_be.service;
 
 import com.google.gson.JsonObject;
-import com.wap.cano_be.dto.oauth2.OAuth2LoginDto;
-import com.wap.cano_be.dto.oauth2.TestLoginDto;
+import com.wap.cano_be.dto.auth.OAuth2LoginDto;
+import com.wap.cano_be.dto.auth.LoginRequestDto;
 import org.springframework.http.ResponseEntity;
 
 public interface OAuth2LoginService<T> {
     ResponseEntity<T> oauth2Login(OAuth2LoginDto oAuth2LoginDto);
-    JsonObject getUserInfoFromToken(TestLoginDto requestDto);
+    JsonObject getUserInfoFromToken(LoginRequestDto requestDto);
 }

--- a/src/main/java/com/wap/cano_be/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/wap/cano_be/service/impl/AuthServiceImpl.java
@@ -23,7 +23,6 @@ import org.springframework.web.client.RestTemplate;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/wap/cano_be/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/wap/cano_be/service/impl/AuthServiceImpl.java
@@ -1,0 +1,91 @@
+package com.wap.cano_be.service.impl;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.wap.cano_be.domain.Member;
+import com.wap.cano_be.domain.enums.MemberRole;
+import com.wap.cano_be.dto.auth.LoginRequestDto;
+import com.wap.cano_be.dto.auth.LoginResponseDto;
+import com.wap.cano_be.repository.MemberRepository;
+import com.wap.cano_be.security.JwtConstants;
+import com.wap.cano_be.security.JwtUtils;
+import com.wap.cano_be.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+    private final MemberRepository memberRepository;
+
+    @Override
+    public ResponseEntity<LoginResponseDto> kakaoLogin(LoginRequestDto requestDto) {
+        JsonObject response = getUserInfoFromToken(requestDto.getToken());
+
+        // 카카오 토큰에서 이메일 추출
+        String email = response.get("kakao_account").getAsJsonObject().get("email").getAsString();
+
+        // 이메일로 Member 검색
+        Optional<Member> memberOptional = memberRepository.findByEmail(email);
+
+        Member member;
+        if (memberOptional.isPresent()) {
+            // 기존 멤버가 있는 경우, 멤버 정보 사용
+            member = memberOptional.get();
+        } else {
+            // Member가 없는 경우 새 멤버 추가
+            member = Member.builder()
+                    .email(email)
+                    .socialId(response.get("id").getAsString())
+                    .providerId("kakao")
+                    .role(MemberRole.USER)
+                    .build();
+
+            memberRepository.save(member);
+        }
+
+        // AccessToken 생성
+        Map<String, Object> accessTokenClaims = new HashMap<>();
+        accessTokenClaims.put("email", member.getEmail());
+        accessTokenClaims.put("role", member.getRole());
+        String accessToken = JwtUtils.generateToken(accessTokenClaims, JwtConstants.ACCESS_EXP_TIME);
+
+        // RefreshToken 생성
+        // AccessToken 생성
+        Map<String, Object> refreshTokenClaims = new HashMap<>();
+        refreshTokenClaims.put("email", member.getEmail());
+        refreshTokenClaims.put("role", member.getRole());
+        String refreshToken = JwtUtils.generateToken(refreshTokenClaims, JwtConstants.REFRESH_EXP_TIME)
+
+        return ResponseEntity.ok().body(new LoginResponseDto(accessToken, refreshToken));
+    }
+
+    private JsonObject getUserInfoFromToken(String token) {
+        final String KAKAO_USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + token);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                KAKAO_USER_INFO_URL,
+                HttpMethod.POST,
+                entity,
+                String.class
+        );
+
+        Gson gson = new Gson();
+
+        return gson.fromJson(response.getBody(), JsonObject.class);
+    }
+}

--- a/src/main/java/com/wap/cano_be/service/impl/KakaoOAuth2LoginService.java
+++ b/src/main/java/com/wap/cano_be/service/impl/KakaoOAuth2LoginService.java
@@ -77,63 +77,64 @@ public class KakaoOAuth2LoginService implements OAuth2LoginService {
 
     @Override
     public ResponseEntity<ResponseDto> oauth2Login(OAuth2LoginDto oAuth2LoginDto){
-        log.info("-------------------KakaoOAuth2APIService----------------------------");
-        fetchAttributes(oAuth2LoginDto); // attribute
-
-        if("NO_TOKEN".equals(attributes.get("NT"))){
-            return ResponseEntity.badRequest().body(new ResponseDto("NO_TOKEN", "토큰이 없습니다."));
-        }
-
-        if("CERTIFICATION_FAIL".equals(attributes.get("CF"))) {
-            return OAuth2UserResponseDto.certificationFail();
-        }
-
-        if(ResponseCode.VALIDATION_FAIL.name().equals(attributes.get(ResponseCode.VALIDATION_FAIL.name()))){
-            return ResponseDto.validationFail();
-        }
-
-        OAuth2UserInfo kakaoUserInfo = null;
-        try {
-            log.info("=====OAuth2UserInfo 생성=====");
-            kakaoUserInfo = OAuth2UserInfo.of("kakao", attributes); // OAuth2User 구현체
-        } catch (AuthException e) {
-            log.warn("=====!OAuth2UserInfo 생성 실패!=====");
-            return ResponseEntity.internalServerError().body(new ResponseDto("error", e.getMessage()));
-        }
-
-        if(kakaoUserInfo == null){
-            log.info("유저 생성에 실패했습니다.");
-            return ResponseDto.noSuchUser();
-        }
-
-        Optional<Member> findUser = memberRepository.findBySocialId(kakaoUserInfo.socialId());
-        OAuth2UserInfo finalKakaoUserInfo = kakaoUserInfo;
-
-        log.info("Token generate");
-
-        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
-        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
-        Map<String, Object> claim = new HashMap<>();
-
-        claim.put("id", attributes.get("id"));
-        claim.put("name", profile.get("nickname"));
-        claim.put("email", account.get("email"));
-        claim.put("role", "USER");
-
-        String accessToken = JwtUtils.generateToken(claim, JwtConstants.ACCESS_EXP_TIME);
-        log.info("access token = {}", accessToken);
-        if(accessToken.isEmpty()){
-            return ResponseEntity.internalServerError().body(new ResponseDto(ResponseCode.VALIDATION_FAIL.name(), "Jwt 토큰이 정상적으로 생성되지 않았습니다."));
-        }
-
-        RefreshToken refreshToken = new RefreshToken(JwtUtils.generateToken(claim, JwtConstants.REFRESH_EXP_TIME));
-        refreshTokenRepository.save(refreshToken);
-
-        Member member = findUser.orElseGet(() -> saveSocialMember(finalKakaoUserInfo));
-        member.setRefreshToken(refreshToken);
-        member.setProviderId("kakao");
-
-        return ResponseEntity.ok().header(JwtConstants.JWT_HEADER, accessToken).body(new ResponseDto());
+//        log.info("-------------------KakaoOAuth2APIService----------------------------");
+//        fetchAttributes(oAuth2LoginDto); // attribute
+//
+//        if("NO_TOKEN".equals(attributes.get("NT"))){
+//            return ResponseEntity.badRequest().body(new ResponseDto("NO_TOKEN", "토큰이 없습니다."));
+//        }
+//
+//        if("CERTIFICATION_FAIL".equals(attributes.get("CF"))) {
+//            return OAuth2UserResponseDto.certificationFail();
+//        }
+//
+//        if(ResponseCode.VALIDATION_FAIL.name().equals(attributes.get(ResponseCode.VALIDATION_FAIL.name()))){
+//            return ResponseDto.validationFail();
+//        }
+//
+//        OAuth2UserInfo kakaoUserInfo = null;
+//        try {
+//            log.info("=====OAuth2UserInfo 생성=====");
+//            kakaoUserInfo = OAuth2UserInfo.of("kakao", attributes); // OAuth2User 구현체
+//        } catch (AuthException e) {
+//            log.warn("=====!OAuth2UserInfo 생성 실패!=====");
+//            return ResponseEntity.internalServerError().body(new ResponseDto("error", e.getMessage()));
+//        }
+//
+//        if(kakaoUserInfo == null){
+//            log.info("유저 생성에 실패했습니다.");
+//            return ResponseDto.noSuchUser();
+//        }
+//
+//        Optional<Member> findUser = memberRepository.findBySocialId(kakaoUserInfo.socialId());
+//        OAuth2UserInfo finalKakaoUserInfo = kakaoUserInfo;
+//
+//        log.info("Token generate");
+//
+//        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+//        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+//        Map<String, Object> claim = new HashMap<>();
+//
+//        claim.put("id", attributes.get("id"));
+//        claim.put("name", profile.get("nickname"));
+//        claim.put("email", account.get("email"));
+//        claim.put("role", "USER");
+//
+//        String accessToken = JwtUtils.generateToken(claim, JwtConstants.ACCESS_EXP_TIME);
+//        log.info("access token = {}", accessToken);
+//        if(accessToken.isEmpty()){
+//            return ResponseEntity.internalServerError().body(new ResponseDto(ResponseCode.VALIDATION_FAIL.name(), "Jwt 토큰이 정상적으로 생성되지 않았습니다."));
+//        }
+//
+//        RefreshToken refreshToken = new RefreshToken(JwtUtils.generateToken(claim, JwtConstants.REFRESH_EXP_TIME));
+//        refreshTokenRepository.save(refreshToken);
+//
+//        Member member = findUser.orElseGet(() -> saveSocialMember(finalKakaoUserInfo));
+//        member.setRefreshToken(refreshToken);
+//        member.setProviderId("kakao");
+//
+//        return ResponseEntity.ok().header(JwtConstants.JWT_HEADER, accessToken).body(new ResponseDto());
+        return null;
     }
 
     // 소셜 ID 로 가입된 사용자가 없으면 새로운 사용자를 만들어 저장한다

--- a/src/main/java/com/wap/cano_be/service/impl/KakaoOAuth2LoginService.java
+++ b/src/main/java/com/wap/cano_be/service/impl/KakaoOAuth2LoginService.java
@@ -10,12 +10,12 @@ import com.wap.cano_be.security.JwtConstants;
 import com.wap.cano_be.security.JwtUtils;
 import com.wap.cano_be.domain.Member;
 import com.wap.cano_be.domain.enums.MemberRole;
-import com.wap.cano_be.dto.oauth2.OAuth2LoginDto;
-import com.wap.cano_be.dto.oauth2.OAuth2UserResponseDto;
+import com.wap.cano_be.dto.auth.OAuth2LoginDto;
+import com.wap.cano_be.dto.auth.OAuth2UserResponseDto;
 import com.wap.cano_be.repository.MemberRepository;
-import com.wap.cano_be.dto.oauth2.TestLoginDto;
+import com.wap.cano_be.dto.auth.LoginRequestDto;
 import com.wap.cano_be.service.OAuth2LoginService;
-import com.wap.cano_be.dto.oauth2.OAuth2UserInfo;
+import com.wap.cano_be.dto.auth.OAuth2UserInfo;
 import jakarta.security.auth.message.AuthException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -151,13 +151,13 @@ public class KakaoOAuth2LoginService implements OAuth2LoginService {
     }
 
     @Override
-    public JsonObject getUserInfoFromToken(TestLoginDto testLoginDto) {
-        log.info("token: " + testLoginDto.getToken());
+    public JsonObject getUserInfoFromToken(LoginRequestDto loginRequestDto) {
+        log.info("token: " + loginRequestDto.getToken());
         final String KAKAO_USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
 
         RestTemplate restTemplate = new RestTemplate();
         HttpHeaders headers = new HttpHeaders();
-        headers.set("Authorization", "Bearer " + testLoginDto.getToken());
+        headers.set("Authorization", "Bearer " + loginRequestDto.getToken());
         HttpEntity<String> entity = new HttpEntity<>(headers);
 
         ResponseEntity<String> response = restTemplate.exchange(
@@ -174,8 +174,8 @@ public class KakaoOAuth2LoginService implements OAuth2LoginService {
         return gson.fromJson(response.getBody(), JsonObject.class);
     }
 
-    public ResponseEntity<?> kakaoLogin(TestLoginDto testLoginDto) {
-        JsonObject response = getUserInfoFromToken(testLoginDto);
+    public ResponseEntity<?> kakaoLogin(LoginRequestDto loginRequestDto) {
+        JsonObject response = getUserInfoFromToken(loginRequestDto);
         // 카카오 토큰에서 이메일 추출
         String email = response.get("kakao_account").getAsJsonObject().get("email").getAsString();
 


### PR DESCRIPTION
- Redis 종속성 추가 및 RedisConfig 추가.
- AuthService 및 AuthServiceImpl 추가.
- Kakao 로그인 API 엔드포인트 수정. (oauth2/login/kakao -> api/auth/login/kakao)
- Member 엔티티에서 RefeshToken 연관관계 제거.
- 각 토큰 만료기간 수정 (10분 -> 1시간, 24시간 -> 일주일)

![image](https://github.com/user-attachments/assets/cc0ba0ea-93a7-4005-a511-1fa070f0bd5a)
- Kakao AccessToken으로 로그인 요청 시 서버 AccessToken과 RefreshToken 반환

![image](https://github.com/user-attachments/assets/ff167d70-71ec-46bb-9440-00455d67c991)
- Redis에 저장된 RefreshToken